### PR TITLE
Update kill logic

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,15 +44,13 @@ workflow_id=$(curl -s ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/workflows
 echo "workflow id: "$workflow_id
 
 # get the run id
-run_ids=$(curl -s ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_id}/runs -H "${auth_header}" | jq "${jq_run_id}")
+run_ids=$(curl -s ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_id}/runs -H "${auth_header}" | jq "${jq_run_id}" | sort -n | head -n-1)
 
 echo "run ids: "$run_ids
 
 # cancel the previous runs
 for run_id in $run_ids
 do
-  if [ "$run_id" != "$GITHUB_RUN_ID" ]; then
-    curl -s -X POST -H "${auth_header}" ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel
-    echo "Cancelled run $run_id"
-  fi
+  curl -s -X POST -H "${auth_header}" ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel
+  echo "Cancelled run $run_id"
 done


### PR DESCRIPTION
Kill all runs, except for latest. Even if that includes ourselves. A delay in bringing up docker containers can otherwise cause newer runs to be killed by older ones.