### PR TITLE
Update kill logic

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ else
 fi
 
 # jq queries
-jq_run_id=".workflow_runs | .[] | select(.head_branch==\"${BRANCH}\" and (.status==\"in_progress\" or .status==\"queued\")) | .id"
+jq_run_ids=".workflow_runs | .[] | select(.head_branch==\"${BRANCH}\" and (.status==\"in_progress\" or .status==\"queued\")) | .id"
 
 # get the github workflow ID
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,16 +41,14 @@ workflow_url=$(curl -s ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/runs/${G
 workflow_id=${workflow_url##/*/}
 echo "workflow id: "$workflow_id
 
-# get the run ids
-run_ids=$(curl -s ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_id}/runs -H "${auth_header}" | jq -r "${jq_run_id}")
+# get the run id
+run_ids=$(curl -s ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_id}/runs -H "${auth_header}" | jq -r "${jq_run_id}" | sort -n | head -n-1)
 
 echo "run ids: "$run_ids
 
 # cancel the previous runs
 for run_id in $run_ids
 do
-  if [ "$run_id" != "$GITHUB_RUN_ID" ]; then
-    curl -s -X POST -H "${auth_header}" ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel
-    echo "Cancelled run $run_id"
-  fi
+  curl -s -X POST -H "${auth_header}" ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel
+  echo "Cancelled run $run_id"
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ workflow_url=$(curl -s ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/runs/${G
 workflow_id=${workflow_url##/*/}
 echo "workflow id: "$workflow_id
 
-# get the run id
+# get the run ids
 run_ids=$(curl -s ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_id}/runs -H "${auth_header}" | jq -r "${jq_run_id}" | sort -n | head -n-1)
 
 echo "run ids: "$run_ids

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,7 @@ workflow_id=${workflow_url##/*/}
 echo "workflow id: "$workflow_id
 
 # get the run ids
-run_ids=$(curl -s ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_id}/runs -H "${auth_header}" | jq -r "${jq_run_id}" | sort -n | head -n-1)
+run_ids=$(curl -s ${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_id}/runs -H "${auth_header}" | jq -r "${jq_run_ids}" | sort -n | head -n-1)
 
 echo "run ids: "$run_ids
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ else
 fi
 
 # jq queries
-jq_run_id=".workflow_runs | .[] | select(.head_branch==\"${BRANCH}\" and .status==\"in_progress\") | .id"
+jq_run_id=".workflow_runs | .[] | select(.head_branch==\"${BRANCH}\" and (.status==\"in_progress\" or .status==\"queued\")) | .id"
 
 # get the github workflow ID
 


### PR DESCRIPTION
originally opened by @tun0: Kill all runs, except for latest. Even if that includes ourselves. A delay in bringing up docker containers can otherwise cause newer runs to be killed by older ones.