### PR TITLE
feat: enabled workflow cancellation for "Waiting" workflows

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ else
 fi
 
 # jq queries
-jq_run_ids=".workflow_runs | .[] | select(.head_branch==\"${BRANCH}\" and (.status==\"in_progress\" or .status==\"queued\")) | .id"
+jq_run_ids=".workflow_runs | .[] | select(.head_branch==\"${BRANCH}\" and (.status==\"in_progress\" or .status==\"queued\" or .status==\"waiting\")) | .id"
 
 # get the github workflow ID
 


### PR DESCRIPTION
Hey @rokroskar, hope you don't mind I get my hands in this!

Sorry for the commit message, I didn't really plan on opening a PR initially - but I believe if you choose "Squash and merge" it should get rid of my commit message and allow you to use the title of the PR as one.

GitHub has recently enabled Environment protections, which means that workflows can now be marked as "Waiting" - if you have it enabled. It'll look something like this:

![image](https://user-images.githubusercontent.com/9394141/103594497-220c8080-4ef9-11eb-8dbd-65f1a9510b4c.png)

I tried it in my fork and a private repo and it seemed to work :p

