### PR TITLE
fix: workflow now cancels itself when newer workflow is detected

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,16 @@ function convertToKeyValuePairs() {
 }
 
 function getRunningWorkflowIds() {
-  jq ".workflow_runs | .[] | select(.head_branch==\"${branch?}\" and .head_repository.full_name==\"${repo?}\" and .status==\"in_progress\" or .status==\"queued\" or .status== \"waiting\") | .id " | grep -v "${GITHUB_RUN_ID}" || :
+  local workflow_ids
+  workflow_ids=$(jq ".workflow_runs | .[] | select(.head_branch==\"${branch?}\" and .head_repository.full_name==\"${repo?}\" and .status==\"in_progress\" or .status==\"queued\" or .status== \"waiting\") | .id ")
+  local condition="<"
+  for id in $workflow_ids; do
+    if [[ "$id" -gt "$GITHUB_RUN_ID" ]]; then
+      condition="<="
+      break
+    fi
+  done
+  echo "$workflow_ids" | jq "select( . $condition $GITHUB_RUN_ID )"
 }
 
 function exportAll() {


### PR DESCRIPTION
Hey @rokroskar,

here's the improvement regarding issue #21.

I decided to replace the hacky grep with a jq call.
This PR assumes that the run ids are incremental. I didn't confirm this from any documentation. Was just an observation. Maybe we should verify that assumtion?

closes #21 