### PR TITLE
Added missing -r to remove quotes from repo

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,7 @@ auth_header="Authorization: token ${GITHUB_TOKEN}"
 meta_data="$( curl -s "${GITHUB_API}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" -H "${auth_header}" -H "${ACCEPT_HEADER}" | extractMetaInformation )"
 workflow_id="$( echo "$meta_data" | jq -r ".${WORKFLOW_ID_KEY}" )"
 branch="$( echo "$meta_data" | jq -r ".${BRANCH_KEY}" )"
-repo="$( echo "$meta_data" | jq ".${REPO_KEY}" )"
+repo="$( echo "$meta_data" | jq -r ".${REPO_KEY}" )"
 
 echo "workflow id: ${workflow_id}"
 echo "branch: ${branch}"


### PR DESCRIPTION
The repo value was including quotes and when used in the call to fetch the `workflow_ids`, it would be double quoted and cause a syntax error:

```
jq: error: syntax error, unexpected IDENT, expecting ';' or ')' (Unix shell quoting issues?) at <top-level>, line 1:
.workflow_runs | .[] | select(.head_branch=="branch" and .head_repository.full_name==""repo/repo"" and (.status=="in_progress" or .status=="queued" or .status== "waiting")) | .id                                                                                                 
```